### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "Npm "

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## React Photo Portfolio w/ Blog utilizing Contentful
+[![Run on Repl.it](https://repl.it/badge/github/circuitsyn/ReactPhotoPortfolio)](https://repl.it/github/circuitsyn/ReactPhotoPortfolio)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@circuitsyn/ReactPhotoPortfolio).